### PR TITLE
Ignore placeholder stream titles; refine battery handling

### DIFF
--- a/builds/trip5/web_assets/firmware-info.json
+++ b/builds/trip5/web_assets/firmware-info.json
@@ -1,7 +1,7 @@
 {
   "project": "ehRadio",
   "version": "2026.02.18",
-  "build_date": "2026-02-19 03:19:46 UTC",
+  "build_date": "2026-02-19 03:53:10 UTC",
   "variants": [
   {
     "name": "Trip5 OLED with Remote",

--- a/src/libraries/I2S_Audio/Audio.cpp
+++ b/src/libraries/I2S_Audio/Audio.cpp
@@ -4388,6 +4388,17 @@ void Audio::showstreamtitle(const char* ml) {
         }
         else sTit = strdup(ml);
 
+        /* Quick-ignore common placeholder titles (e.g. StreamTitle='-' or empty) before further processing */
+        {
+          uint8_t _pos_tmp = 12;
+          if (sTit[_pos_tmp] == '\'') _pos_tmp++;
+          char* _tp = sTit + _pos_tmp;
+          while(*_tp == ' ' || *_tp == '\t' || *_tp == '\r' || *_tp == '\n') _tp++;
+          size_t _tlen = strlen(_tp);
+          if (_tlen > 0 && _tp[_tlen - 1] == '\'') _tp[_tlen - 1] = '\0';
+          if (_tp[0] == '\0' || (_tp[0] == '-' && _tp[1] == '\0')) { x_ps_free(&sTit); return; }
+        }
+
         while(i < strlen(sTit)) {
             hash += sTit[i] * i + 1;
             i++;

--- a/src/libraries/VS1053_Audio/audioVS1053Ex.cpp
+++ b/src/libraries/VS1053_Audio/audioVS1053Ex.cpp
@@ -918,12 +918,30 @@ void Audio::showstreamtitle(const char* ml) {
 
         if(m_streamTitleHash != hash) {
             m_streamTitleHash = hash;
-//            AUDIO_INFO("%s", sTit);
-           AUDIO_INFO("%.*s", m_ibuffSize, sTit);
+
             uint8_t pos = 12;                                                 // remove "StreamTitle="
             if(sTit[pos] == '\'') pos++;                                      // remove leading  \'
-            if(sTit[strlen(sTit) - 1] == '\'') sTit[strlen(sTit) - 1] = '\0'; // remove trailing \'
-            if(audio_showstreamtitle) audio_showstreamtitle(sTit + pos);
+            size_t sLen = strlen(sTit);
+            if (sLen > 0 && sTit[sLen - 1] == '\'') sTit[sLen - 1] = '\0'; // remove trailing \'
+
+            /* Trim and ignore placeholder titles such as "-" or empty strings.
+               Remembering the hash prevents repeated placeholder logging. */
+            char* titlePtr = sTit + pos;
+            while(*titlePtr == ' ' || *titlePtr == '\t' || *titlePtr == '\r' || *titlePtr == '\n') titlePtr++;
+            char* endp = titlePtr + strlen(titlePtr);
+            if (endp > titlePtr) {
+                endp--;
+                while(endp >= titlePtr && (*endp == ' ' || *endp == '\t' || *endp == '\r' || *endp == '\n')) { *endp = '\0'; if (endp == titlePtr) break; endp--; }
+            }
+
+            if (titlePtr[0] == '\0' || (titlePtr[0] == '-' && titlePtr[1] == '\0')) {
+                #ifdef AUDIO_DEBUG
+                  AUDIO_INFO("StreamTitle ignored (placeholder): '%s'", titlePtr);
+                #endif
+            } else {
+                AUDIO_INFO("%.*s", m_ibuffSize, sTit);
+                if(audio_showstreamtitle) audio_showstreamtitle(titlePtr);
+            }
         }
         x_ps_free(&sTit);
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -199,12 +199,15 @@ void loop() {
 void battery_dim_loop() {
   BatteryStatus bat = battery_get_status();
 
+  /* Decide charging based on explicit detection or the existing inference logic only. */
+  bool is_charging_present = bat.charging || bat.charging_inferred;
+
   /* Critical battery: stop playback, blank display and go to deep sleep (once)
      If a charger (TP4054) is present and the battery is charging, skip deep sleep
      while charging and notify once. Deep-sleep will occur once charging stops.
-     Grace period: wait 30 seconds after boot before allowing deep sleep. */
-  if (bat.critical_battery && !battery_critical_handled && millis() > 30000) {
-    if (bat.charging) {
+     Grace period: wait ~5 minutes after boot before allowing deep sleep. */
+  if (bat.critical_battery && !battery_critical_handled && millis() > 300000) {
+    if (is_charging_present) {
       if (!battery_critical_skipped) {
         battery_critical_skipped = true;
         Serial.printf("##[BATTERY]#: CRITICAL battery (%d%%) but charging - skipping deep sleep\r\n", bat.percentage);
@@ -232,29 +235,36 @@ void battery_dim_loop() {
     }
   }
 
-  // Low battery: force fixed brightness percentage
+  // Low battery: force fixed brightness percentage (skip dimming while charging)
   if (bat.low_battery && !battery_low_handled) {
-    battery_low_handled = true;
-    if (!battery_saved_valid) { battery_saved_brightness = config.store.brightness; battery_saved_valid = true; }
-    uint8_t target_pct = (uint8_t)BATTERY_DIM_BRIGHTNESS;
-    if (target_pct > 100) target_pct = 100;
-    Serial.printf("##[BATTERY]#: LOW battery (%d%%) - forcing brightness to %d%%\r\n", bat.percentage, target_pct);
-    config.store.brightness = target_pct;
-    #if defined(DOWN_LEVEL) || defined(DOWN_INTERVAL)
-      brightnessOn();
-    #else
-      config.setBrightness(false);
-    #endif
+    if (is_charging_present) {
+      /* When charging (or charging trend detected), do not force a low-battery brightness — avoid flicker. */
+      #ifdef BATTERY_DEBUG
+        Serial.printf("##[BATTERY]#: LOW battery (%d%%) but charging/trend detected - skipping forced brightness\r\n", bat.percentage);
+      #endif
+    } else {
+      battery_low_handled = true;
+      if (!battery_saved_valid) { battery_saved_brightness = config.store.brightness; battery_saved_valid = true; }
+      uint8_t target_pct = (uint8_t)BATTERY_DIM_BRIGHTNESS;
+      if (target_pct > 100) target_pct = 100;
+      Serial.printf("##[BATTERY]#: LOW battery (%d%%) - forcing brightness to %d%%\r\n", bat.percentage, target_pct);
+      config.store.brightness = target_pct;
+      #if defined(DOWN_LEVEL) || defined(DOWN_INTERVAL)
+        brightnessOn();
+      #else
+        config.setBrightness(false);
+      #endif
+    }
   }
 
-  // Restore when battery OK (with hysteresis) or charging
+  // Restore when battery OK (with hysteresis) or charging/trend detected
   {
     int recover = (int)BATTERY_LOW_THRESHOLD + (int)BATTERY_RECOVER_HYSTERESIS_PCT;
     if (recover > 100) recover = 100;
     uint8_t recover_pct = (uint8_t)recover;
     bool recovered_by_pct = (bat.percentage >= recover_pct) && !bat.critical_battery;
 
-    if ((battery_low_handled && recovered_by_pct) || (battery_critical_handled && !bat.critical_battery) || bat.charging) {
+    if ((battery_low_handled && recovered_by_pct) || (battery_critical_handled && !bat.critical_battery) || is_charging_present) {
       if (battery_low_handled) {
         battery_low_handled = false;
         if (battery_saved_valid) {


### PR DESCRIPTION
Audio: Add trimming and quick-ignore logic for common placeholder StreamTitle values (empty or "-") in both I2S_Audio and VS1053 implementations; strip surrounding quotes/whitespace, avoid logging/dispatching placeholders and keep hash to prevent repeated noise.

Main: Consolidate charging detection into is_charging_present (uses explicit or inferred flag), increase critical-battery deep-sleep grace period to ~5 minutes, skip deep-sleep and low-battery brightness forcing while charging/trend detected, and use the unified charging flag when restoring brightness/behavior. These changes reduce placeholder stream spam and prevent unwanted deep-sleep/brightness flicker during charging or charging trends.