### PR TITLE
Enable Lithuanian DSP macro and add ESP32 env

### DIFF
--- a/builds/kasperaitis/myoptions.h
+++ b/builds/kasperaitis/myoptions.h
@@ -71,7 +71,7 @@
   #define TFT_SCLK        12
   #define TFT_MISO        13
   #define BRIGHTNESS_PIN  TFT_BL
-  #define DSP_LANGUAGE    lt_LT
+  #define DSP_LANGUAGE_lt_LT
 #endif
 
 

--- a/builds/kasperaitis/platformio.ini
+++ b/builds/kasperaitis/platformio.ini
@@ -24,9 +24,9 @@ lib_deps =
   jnthas/Improv WiFi Library@^0.0.4
 
   ; Input libraries (include in specific builds as needed)
-  ;mathertel/OneButton@^2.6.1
+  ;mathertel/OneButton@^2.6.2
   ;igorantolic/Ai Esp32 Rotary Encoder@^1.7
-  ;crankyoldgit/IRremoteESP8266@^2.9.0 ; untested but should be fine
+  ;crankyoldgit/IRremoteESP8266@^2.9.0
 
   ; Display libraries (just some examples, generally use Adafruit drivers)
   ;adafruit/Adafruit GC9A01A@^1.1.0 ; untested - may need to try 1.0.0
@@ -62,9 +62,23 @@ build_src_filter =
   ;+<libraries/VS1053_Audio/*>
 
 ; These steps package do pre- and post-steps to make sure SPIFFS gets .gz files for www and an edited font for Wi-Fi signal bars
-extra_scripts = pre:builds/platformio_pre_replace_font.py, pre:builds/platformio_pre_gzip_www.py, post:builds/platformio_post_gzip_www.py
+extra_scripts = pre:builds/platformio_pre_localize.py, pre:builds/platformio_pre_gzip_www.py, post:builds/platformio_post_gzip_www.py
 
 ; --- Bare board firmwares ---
+
+[env:board_esp32]
+extends = env
+board = esp32dev
+build_flags =
+  ${env.build_flags}
+board_build.extra_flags =
+  -DBOARD_ESP32
+lib_deps =
+  ${env.lib_deps}
+build_src_filter =
+  ${env.build_src_filter}
+  +<libraries/I2S_Audio/*>
+board_build.partitions = builds/4MBflash.csv
 
 [env:board_esp32_s3_n16r8]
 extends = env


### PR DESCRIPTION
Fix myoptions.h by correcting the DSP language define (switch to defining DSP_LANGUAGE_lt_LT). Update platformio.ini: replace the pre-font-replace script with a pre_localize step, update a commented OneButton version, remove an inline comment on IRremoteESP8266, and add a new [env:board_esp32] target (esp32dev) with I2S_Audio included and a 4MB partition table. These changes add localization/preprocessing and a dedicated ESP32 build configuration.